### PR TITLE
correct total disk available calculation

### DIFF
--- a/grafana-config/grafana-dashboards/kubernetes-cluster-overview.json
+++ b/grafana-config/grafana-dashboards/kubernetes-cluster-overview.json
@@ -1229,7 +1229,7 @@
           },
           "targets": [
             {
-              "expr": "sum(container_fs_limit_bytes{job=\"kubernetes-nodes\", kubernetes_io_hostname=~\"^$node$\"})",
+              "expr": "sum(container_fs_limit_bytes{job=\"kubernetes-nodes\", kubernetes_io_hostname=~\"^$node$\", id=\"/\"})",
               "interval": "10s",
               "intervalFactor": 1,
               "legendFormat": "",


### PR DESCRIPTION
Without id=/, the calculated total disk is way off as it counts all /system.slice/docker*