### PR TITLE
make prometheus communicate with alertmanager

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ oadm policy add-scc-to-user privileged system:serviceaccount:monitoring:node-exp
 
 oc new-app prom/alertmanager
 oc annotate svc alertmanager prometheus.io/scrape='true'
-oc annotate svc alertmanager prometheus.io/path='/alertmanager/metrics'
+oc annotate svc alertmanager prometheus.io/path='/metrics'
 oc create configmap alertmanager-templates --from-file=alertmanager-config/alertmanager-templates
 oc create -f alertmanager-config/alertmanager-configmap.yaml
 oc volume --add dc/alertmanager --name config-volume     -t configmap --configmap-name  alertmanager-configmap -m /etc/alertmanager           --overwrite

--- a/prometheus-config/prometheus-configmap.yaml
+++ b/prometheus-config/prometheus-configmap.yaml
@@ -279,4 +279,11 @@ data:
         regex: 'kubernetes-(.*)'
         replacement: '${1}'
         target_label: name
-    
+
+    alerting:
+      alertmanagers:
+      - scheme: http
+        static_configs:
+        - targets:
+          - "alertmanager:9093"
+


### PR DESCRIPTION
- the annotate path was not reflecting the alertmanager path. Perhaps due to a recent change in alertmanager
- alertmanager url was not set and thus no alert was sent.